### PR TITLE
docs: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vite-plugin-eslint2
 
-English | [简体中文](./README-zh_CN.md)
+English | [简体中文](./README.zh-CN.md)
 
 👇 See the documentation for specific usage and examples.
 


### PR DESCRIPTION
### Description 描述

Currently the link to the Chinese README in the english README is incorrect. This PR replaces the link with the correct filename `README.zh-CN.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the link to the Chinese version of the documentation for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->