### PR TITLE
fix: eslintInstance may not be initialized when calling lintFiles in the worker

### DIFF
--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -33,6 +33,7 @@ const initPromise = initializeESLint(options).then((result) => {
 // so we use iife here
 (async () => {
   debug("Initialize ESLint");
+  // remove this line will cause ts2454
   const { eslintInstance, formatter, outputFixes } = await initPromise;
   if (options.lintOnStart) {
     debug("Lint on start");
@@ -47,6 +48,7 @@ const initPromise = initializeESLint(options).then((result) => {
 })();
 
 parentPort?.on("message", async (files) => {
+  // make sure eslintInstance is initialized
   if (!eslintInstance) await initPromise;
   debug("==== message event ====");
   debug(`message: ${files}`);


### PR DESCRIPTION
### Description 描述

修复在worker模式下因异步问题导致经常报错 Cannot read properties of undefined (reading 'lintFiles')

### Linked Issues 关联的 Issues


### Additional context 额外上下文
![image](https://github.com/user-attachments/assets/1ca3b68b-83e3-4698-bee3-9ba1fcd92766)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved initialization logic for ESLint, enhancing control flow and ensuring readiness before processing messages.

- **Bug Fixes**
	- Resolved issues related to asynchronous handling during ESLint initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->